### PR TITLE
Update node version in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,5 +25,5 @@ inputs:
     required: false
     default: false
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
![Screen Shot 2021-07-15 at 1 06 56 PM](https://user-images.githubusercontent.com/2223770/125851544-b49f17f8-190b-4026-99fe-ae9c24dd22c1.png)

The action expects node16, otherwise we'll get run time errors like that. Update the action to use the same major version as our `.tool-version` file.