### PR TITLE
assign chris for dependency PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,5 @@ updates:
     # Check the npm registry for updates every day (weekdays)
     schedule:
       interval: 'weekly'
+    assignees:
+      - "chrisdchow"


### PR DESCRIPTION
I don't think TIDE needs to be involved for dependabot updates.